### PR TITLE
to fix the version of guzzle-services and guzzle-command for guzzle4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
     "description": "Client for consuming the EAN Hotel API, based on Guzzle",
     "require": {
         "php": ">=5.4",
-        "guzzlehttp/guzzle-services": "~0.3"
+        "guzzlehttp/guzzle-services": "0.3.*",
+        "guzzlehttp/command": "0.6.*"
     },
     "require-dev": {
         "guzzlehttp/log-subscriber": "~1.0"


### PR DESCRIPTION
The latest version of guzzlehttp/command and guzzlehttp/guzzle-services is dependent on guzzle 5.
